### PR TITLE
修改macOS version: 10.15.7到macOS version: 10.15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 OpenCore: 0.6.2
 
-macOS version: 10.15.7
+macOS version: 10.15.6
 
 EFI下载地址: [Download](https://github.com/myqqiu/Hackintosh-B460M-MORTAR-i5-10500-iGPU-UHD630/releases)
 


### PR DESCRIPTION
文档中 macOS version: 10.15.7，在实际安装中有概率出现macos系统损坏，最终通过重新安装10.15.6成功。

建议先改成10.15.6；确保新手能100%成功。