### PR TITLE
Quirks属性中删除DeduplicateBootOrder键[仅适用于OC 0.6.5开发版本]

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -949,8 +949,6 @@
 		</dict>
 		<key>Quirks</key>
 		<dict>
-			<key>DeduplicateBootOrder</key>
-			<false/>
 			<key>ExitBootServicesDelay</key>
 			<integer>0</integer>
 			<key>IgnoreInvalidFlexRatio</key>


### PR DESCRIPTION
引导报错：DeduplicateBootOrder键仅适用于OC 0.6.5开发版本，