### PR TITLE
修复cpu型号识别错误

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -794,8 +794,6 @@
 			<false/>
 			<key>MLB</key>
 			<string>C02047501CDPHCDAD</string>
-			<key>ProcessorType</key>
-			<integer>4105</integer>
 			<key>ROM</key>
 			<data>ESIzRFVm</data>
 			<key>SpoofVendor</key>


### PR DESCRIPTION
ProcessorType不当使用造成cpu型号识别错误，建议直接删除。